### PR TITLE
fix: new users can change their temporary password

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -17,7 +17,7 @@ import studentGrades from './operations/studentGrades'
 import MyLayout from './HaLayout'
 import HaLoginPage from './HaLoginPage'
 import { mainTheme } from './haTheme'
-import CompletePassword from './operations/security/CompletePassword'
+import security from './operations/security'
 
 const App = () => (
   <Admin
@@ -29,23 +29,28 @@ const App = () => (
     loginPage={HaLoginPage}
     layout={MyLayout}
     customRoutes={[
-      <Route key='profile' exact path='/profile' component={profile.show} />,
-      <Route key='complete-password' exact path='/complete-password' component={CompletePassword} />
+      <Route key='complete-password' exact path='/complete-password' component={security.create} noLayout/>,
+      <Route key='profile' exact path='/profile' component={profile.show} />
     ]}
   >
     {permissions => {
       // https://marmelab.com/react-admin/doc/3.4/Authorization.html#restricting-access-to-resources-or-views
       const permission = permissions[0]
       return [
+
+        permission === 'guest' && <Resource name='complete-password' />,
+
+        permission === 'MANAGER' && <Resource name='profile' />,
         permission === 'MANAGER' && <Resource name='students' {...students} />,
         permission === 'MANAGER' && <Resource name='teachers' {...teachers} />,
 
+        permission === 'TEACHER' && <Resource name='profile' />,
         permission === 'TEACHER' && <Resource name='students' options={{ label: 'Étudiants' }} list={students.list} show={students.show} />,
 
-        <Resource name='profile' />,
-
+        permission === 'STUDENT' && <Resource name='profile' />,
         permission === 'STUDENT' && <Resource name='fees' {...fees} />,
-        permission === 'STUDENT' && <Resource name='student-grades' {...studentGrades} />
+        permission === 'STUDENT' && <Resource name='student-grades' {...studentGrades} />,
+
       ]
     }}
   </Admin>

--- a/src/HaLoginPage.js
+++ b/src/HaLoginPage.js
@@ -1,4 +1,3 @@
-import React from 'react'
 import { Login } from 'react-admin'
 import Card from '@material-ui/core/Card'
 import CardContent from '@material-ui/core/CardContent'

--- a/src/operations/profile/ProfileShow.js
+++ b/src/operations/profile/ProfileShow.js
@@ -1,7 +1,5 @@
-import React from 'react'
 import { DateField, EmailField, FunctionField, SimpleShowLayout, Show, TextField } from 'react-admin'
 import { Typography } from '@material-ui/core'
-
 import { useAsync } from 'react-async'
 import { useState, useEffect } from 'react'
 import authProvider from '../../providers/authProvider'

--- a/src/operations/profile/index.js
+++ b/src/operations/profile/index.js
@@ -1,4 +1,3 @@
-import React from 'react'
 import ProfileShow from './ProfileShow'
 import { TextInput } from 'react-admin'
 

--- a/src/operations/security/CompletePassword.js
+++ b/src/operations/security/CompletePassword.js
@@ -1,9 +1,8 @@
-import { Auth } from 'aws-amplify'
-import { useRedirect } from 'react-admin'
+import { Auth } from '@aws-amplify/auth'
 import { useState } from 'react'
 
 const CompletePassword = () => {
-  const redirect = useRedirect()
+  const user = JSON.parse(localStorage.getItem('CognitoUser'))
   const [password, setPassword] = useState()
 
   const handleSubmit = event => {
@@ -11,17 +10,17 @@ const CompletePassword = () => {
     Auth.completeNewPassword(user, password)
   }
 
-  const user = Auth.currentAuthenticatedUser()
-  if (user.challengeName !== 'NEW_PASSWORD_REQUIRED') {
-    redirect('/')
-  }
   return (
-    <form onSubmit={handleSubmit}>
-      <label>Nouveau mot de passe :</label>
-      <input type='password' onChange={e => setPassword(e.target.value)} value={password} name='password' />
+    <center>
+      <div>
+        <form onSubmit={handleSubmit}>
+          <label>Nouveau mot de passe :</label>
+          <input type='password' onChange={e => setPassword(e.target.value)} value={password} name='password' />
 
-      <input type='submit' value='Valider' />
-    </form>
+          <input type='submit' value='Valider' />
+        </form>
+      </div>
+    </center>
   )
 }
 export default CompletePassword

--- a/src/operations/security/index.js
+++ b/src/operations/security/index.js
@@ -1,0 +1,7 @@
+import CompletePassword from "./CompletePassword";
+
+const security = {
+    create: CompletePassword
+}
+
+export default security

--- a/src/operations/students/StudentList.js
+++ b/src/operations/students/StudentList.js
@@ -4,7 +4,7 @@ import { profileFilters } from '../profile'
 import PrevNextPagination from '../utils/PrevNextPagination'
 
 const StudentList = props => {
-  const permission = localStorage.getItem('role')
+  const permission = localStorage.getItem('ROLE')
   return (
     <List label='Étudiants' bulkActionButtons={false} {...props} filters={profileFilters} pagination={<PrevNextPagination />}>
       <Datagrid rowClick='show'>

--- a/src/providers/authProvider.ts
+++ b/src/providers/authProvider.ts
@@ -13,13 +13,18 @@ const authProvider = {
   login: ({ username, password, clientMetadata }: Record<string, unknown>): Promise<CognitoUser | unknown> => {
     return Auth.signIn(username as string, password as string, clientMetadata as ClientMetaData).then(user => {
       const session = user.getSignInUserSession()
-      const conf = new Configuration()
-      conf.accessToken = session.getIdToken().getJwtToken()
-      const securityApi = new SecurityApi(conf)
-      securityApi.whoami().then(response => {
-        localStorage.setItem('role', '' + response.data.role)
-      })
-      if (user.challengeName === 'NEW_PASSWORD_REQUIRED') {
+      if (!session) {
+        localStorage.setItem('CognitoUser', JSON.stringify(user))
+        Promise.resolve()
+      } else {
+        const conf = new Configuration()
+        conf.accessToken = session.getIdToken().getJwtToken()
+        const securityApi = new SecurityApi(conf)
+        securityApi.whoami().then(response => {
+          localStorage.setItem('ROLE', '' + response.data.role)
+        })
+        if (user.challengeName === 'NEW_PASSWORD_REQUIRED') {
+        }
       }
     })
   },
@@ -30,11 +35,15 @@ const authProvider = {
   },
 
   checkAuth: async (): Promise<void> => {
-    const session = await Auth.currentSession()
-    if (session && session.getIdToken()) {
-      return
+    if (localStorage.getItem('CognitoUser')) {
+      Promise.resolve()
+    } else {
+      const session = await Auth.currentSession()
+      if (session && session.getIdToken()) {
+        return
+      }
+      throw new Error('Unauthorized')
     }
-    throw new Error('Unauthorized')
   },
 
   checkError: async (): Promise<void> => {
@@ -42,38 +51,49 @@ const authProvider = {
   },
 
   getIdentity: async (): Promise<string> => {
-    const session = await Auth.currentSession()
-    const conf = new Configuration()
-    conf.accessToken = session.getIdToken().getJwtToken()
-    const securityApi = new SecurityApi(conf)
-    return securityApi
-      .whoami()
-      .then((whoami: AxiosResponse<Whoami>) => {
-        return [whoami.data.id]
-      })
-      .catch((error: any) => {
-        console.error(error)
-        return error //TODO
-      })
+    if (localStorage.getItem('CognitoUser')) {
+      return Promise.resolve('guest')
+    } else {
+      const session = await Auth.currentSession()
+      const conf = new Configuration()
+      conf.accessToken = session.getIdToken().getJwtToken()
+      const securityApi = new SecurityApi(conf)
+      return securityApi
+        .whoami()
+        .then((whoami: AxiosResponse<Whoami>) => {
+          return [whoami.data.id]
+        })
+        .catch((error: any) => {
+          console.error(error)
+          return error //TODO
+        })
+    }
   },
 
   getUserInformations: async () => {
-    const session = await Auth.currentSession()
-    const conf = new Configuration()
-    conf.accessToken = session.getIdToken().getJwtToken()
-    const securityApi = new SecurityApi(conf)
-    return securityApi
-      .whoami()
-      .then((whoami: AxiosResponse<Whoami>) => {
-        return { id: whoami.data.id, role: whoami.data.role }
-      })
-      .catch((error: any) => {
-        console.error(error)
-        return error //TODO
-      })
+    if (localStorage.getItem('CognitoUser')) {
+      Promise.resolve({ id: null, role: 'guest' })
+    } else {
+      const session = await Auth.currentSession()
+      const conf = new Configuration()
+      conf.accessToken = session.getIdToken().getJwtToken()
+      const securityApi = new SecurityApi(conf)
+      return securityApi
+        .whoami()
+        .then((whoami: AxiosResponse<Whoami>) => {
+          return { id: whoami.data.id, role: whoami.data.role }
+        })
+        .catch((error: any) => {
+          console.error(error)
+          return error //TODO
+        })
+    }
   },
 
   getPermissions: async (): Promise<string[]> => {
+    if (localStorage.getItem('CognitoUser')) {
+      return Promise.resolve(['guest'])
+    } else {
     const session = await Auth.currentSession()
     const conf = new Configuration()
     conf.accessToken = session.getIdToken().getJwtToken()
@@ -87,12 +107,17 @@ const authProvider = {
         console.error(error)
         return error //TODO
       })
+    }
   },
 
   getToken: async () => {
+    if (localStorage.getItem('CognitoUser')) {
+      Promise.resolve()
+    } else {
     const session = await Auth.currentSession()
     return Promise.resolve(session.getIdToken().getJwtToken())
   }
+}
 }
 
 export default authProvider

--- a/src/providers/dataProvider.js
+++ b/src/providers/dataProvider.js
@@ -27,7 +27,7 @@ const dataProvider = {
     conf.accessToken = authProvider.getToken()
     const usersApi = new UsersApi(conf)
     const id = params.id
-    let role = localStorage.getItem('role')
+    let role = localStorage.getItem('ROLE')
     if (resource === 'profile') {
       if (role === 'STUDENT') {
         return usersApi.getStudentById(id).then(result => {


### PR DESCRIPTION
Until now, the unique issue I found is to use the Amplify Auth UI (withAuthenticator, etc.) but not the default authProvider, because even if the new user is connected as "guest", it is not possible to call the async function provided by AWS Amplify Auth (**Auth.completeNewPassword(user, password)**) inside the submit handle that provides the new password.

![image](https://user-images.githubusercontent.com/88628732/152836481-1a224456-d452-405f-a83c-984e01bfb974.png)

For illustration : 
In line 10, the user and the new right password are provided but the error **[Uncaught Promise user.completeNewPasswordChallenge is not a function** is thrown 